### PR TITLE
Remove temp folder use

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Install MyST Markdown
         run: npm install -g mystmd
       - name: Build HTML Assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_APP_PRIVATE_KEY }}
         run: myst build --html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/plugins/github-issue-table/build.mjs
+++ b/plugins/github-issue-table/build.mjs
@@ -15,7 +15,7 @@ await esbuild.build({
   // Keep readable for debugging (can change to minify for production)
   minify: false,
   // External dependencies that should not be bundled (Node.js built-ins)
-  external: ['crypto', 'fs', 'path', 'os'],
+  external: ['crypto', 'fs', 'path'],
   // Add banner with metadata
   banner: {
     js: `// GitHub Issue Table Plugin for MyST

--- a/plugins/github-issue-table/src/cache.mjs
+++ b/plugins/github-issue-table/src/cache.mjs
@@ -1,9 +1,8 @@
 // Cache Management for GitHub Issue Table Plugin
 
 import { createHash } from "crypto";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
 
 const CACHE_DIR = "_build/temp/github-issues";
 const CACHE_TTL = 24 * 3600000; // 24 hours in milliseconds
@@ -44,19 +43,16 @@ export function readCache(query) {
 }
 
 /**
- * Write data to cache atomically
+ * Write data to cache
  * @param {string} query - Query string
  * @param {Array} items - Items to cache
  */
 export function writeCache(query, items) {
   mkdirSync(CACHE_DIR, { recursive: true });
   const cachePath = getCachePath(query);
-  // Write to temp file first, then atomically rename to prevent corruption
-  const tempPath = join(tmpdir(), `github-cache-${Date.now()}-${Math.random().toString(36).substring(2, 11)}.json`);
-  writeFileSync(tempPath, JSON.stringify({
+  writeFileSync(cachePath, JSON.stringify({
     timestamp: Date.now(),
     query,
     items
   }));
-  renameSync(tempPath, cachePath);
 }


### PR DESCRIPTION
This makes two improvements:

1. Removes the temp folder use and closes #13 
2. Adds the ability to set a different key for the GitHub token