### PR TITLE
Unbreak builds for issue table

### DIFF
--- a/plugins/github-issue-table/package.json
+++ b/plugins/github-issue-table/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.mjs",
   "scripts": {
     "build": "node build.mjs",
-    "test": "vitest run",
+    "lint": "node --check src/*.mjs",
+    "test": "npm run lint && vitest run",
     "test:watch": "vitest watch"
   },
   "keywords": [

--- a/plugins/github-issue-table/src/columns.mjs
+++ b/plugins/github-issue-table/src/columns.mjs
@@ -389,7 +389,7 @@ export const COLUMN_DEFINITIONS = {
       truncateLength: summaryLimit,
       issueUrl: item.url
     });
-  }
+  },
 
   sub_issues: (item, options) => {
     const trackedIssues = item.trackedIssues || [];


### PR DESCRIPTION
I broke the build when I resolved a merge conflict! this also adds a linting step to the test to catch this kind of thing