### PR TITLE
feat: use monospace for labels in `gh-issue-table`

### DIFF
--- a/plugins/github-issue-table/src/columns.mjs
+++ b/plugins/github-issue-table/src/columns.mjs
@@ -330,6 +330,7 @@ export const COLUMN_DEFINITIONS = {
           style: {
             display: "inline-block",
             fontSize: "0.875rem",
+            fontFamily: "monospace",
             whiteSpace: "nowrap",
             padding: "0.125rem 0.5rem",
             margin: "0.125rem 0",


### PR DESCRIPTION
@choldgraf what do you think?

Old
<img width="297" height="139" alt="image" src="https://github.com/user-attachments/assets/367fbbda-653b-482a-aa21-8b7be8134a48" />

New
<img width="337" height="142" alt="image" src="https://github.com/user-attachments/assets/0afb9018-2263-4b5d-a87b-339580eb0820" />

We should also add classes to all of these ... but this is just a drive by for now.