### PR TITLE
Add a build step for the plugins with builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - name: Install MyST Markdown
-        run: npm install -g mystmd
-      - name: Build HTML Assets
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install nox
+        run: pip install nox
+      - name: Build docs
         env:
           GITHUB_TOKEN: ${{ secrets.READ_ONLY_TOKEN }}
-        run: myst build --html
+        run: nox -s docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,25 @@
+from pathlib import Path
+
 import nox
 
 nox.options.default_venv_backend = "uv|virtualenv"
 
 
+@nox.session(python=False)
+def build(session):
+    """Build all plugins that have a build.mjs file."""
+    for build_file in sorted(Path("plugins").glob("*/build.mjs")):
+        plugin_dir = build_file.parent
+        session.log(f"Building {plugin_dir.name}...")
+        with session.chdir(plugin_dir):
+            session.run("npm", "install", external=True, silent=True)
+            session.run("npm", "run", "build", external=True)
+
+
 @nox.session
 def docs(session):
     """Build the documentation as static HTML using MyST."""
+    build(session)
     session.install("mystmd")
     session.run("myst", "build", "--html")
 
@@ -13,6 +27,7 @@ def docs(session):
 @nox.session(name="docs-live")
 def docs_live(session):
     """Start a live development server for the documentation."""
+    build(session)
     session.install("mystmd")
     session.run("myst", "start")
 
@@ -27,7 +42,8 @@ def clean(session):
 @nox.session
 def release(session):
     """Create GitHub releases for plugins.
-    
+
     See src/release.py for details. This just passes args and kwargs to that script.
     """
+    build(session)
     session.run("python", "-m", "src.release", *session.posargs)

--- a/plugins.yml
+++ b/plugins.yml
@@ -12,13 +12,12 @@ project:
     # - plugins/iframe-to-thumbnail-pdf/iframe-to-thumbnail-pdf.mjs
     - https://github.com/jupyter-book/myst-plugins/releases/download/iframe-to-qr-pdf/iframe-to-qr-pdf.mjs
     - https://github.com/jupyter-book/myst-plugins/releases/download/updated-date-frontmatter/update-date-frontmatter.mjs
-    # GitHub plugins: src/ for local dev, dist/ (via esbuild) for distribution
-    - plugins/github-issue-table/src/index.mjs
-    - plugins/github-issue-link/src/index.mjs
-    - plugins/github-handle-links/src/index.mjs
+    # Plugins with build steps (run `nox -s build` first)
+    - plugins/github-issue-table/dist/index.mjs
+    - plugins/github-issue-link/dist/index.mjs
+    - plugins/github-handle-links/dist/index.mjs
+    - plugins/footer/dist/index.mjs
+    # Plugins without build steps
     - plugins/demo/src/index.mjs
     - plugins/emoji-shortcodes/emoji-shortcodes.mjs
     - plugins/page-last-updated/page-last-updated.mjs
-    # Run plugins/footer npm run build first to build the dist/ folder
-    # I think this is needed in order to have the CSS included in the bundle
-    - plugins/footer/dist/index.mjs


### PR DESCRIPTION
For the plugins with `build.mjs` scripts, we were still referring to the "non-built" versions of them, and this was causing some discrepancies between our built docs and local dev workflows. So this PR:

- Adds a `nox -s build` verb
- Builds all plugins with a `build.mjs` file as part of docs builds
- Uses the `dist/` built versions in our demo docs
- Updates our github workflow accordingly