### PR TITLE
Add search filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 This is (as yet) a non-official repository for MyST plugins.
 
+## List of plugins
+```{searchfilter} tr:not(:first-child)
+```
+|name|functionalities|type|requirements|status|maintainer(s)|Embed link|
+|---|---|---|---|---|---|---|
+| page-last-updated | A plugin that automatically slots in the latest update date per page | transform | requires to set fetch depth in deploy.yml `fetch-depth: 0` | tested | Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/page-last-updatedv1.1/page-last-updated.mjs) | 
+| experiment-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/experiment-admonition.mjs) |
+| intermezzo-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/intermezzo-admonition.mjs) |
+| example-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/example-admonition.mjs) |
+| ex-and-sol-pdf | A plugin that converts exercises and solutions to numbered exercises and solutions in both LaTeX and Typst pdf | transform | |stable |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/exercise-and-solution-pdf/exercise-admonition-pdf.mjs) |
+| updated-date-frontmatter | A plugin which adds the date of the last update to the top of the page | | |stable |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/updated-date-frontmatter/update-date-frontmatter.mjs) |
+| iframe | A plugin that replaces iframe elements with a qr code as figure and a caption with the link so that it is accessible in pdf format | transform | | in development |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/iframe-to-qr-pdf/iframe-to-qr-pdf.mjs) |
+| picsum | A plugin that adds a directive to include random images from picsum.photos | directive | | stable | Angus Hollands | - |
+| typst-conversion-support | A plugin that converts missing conversions from Latex to Typst | transform | | in development | Freek Pols | - |
+| github-issue-table | Renders GitHub issues/PRs as tables from search queries or project URLs. Supports custom columns, multi-column sorting, styled labels, and project fields | directive | GITHUB_TOKEN | in development | @choldgraf | - |
+| github-issue-link | Automatically decorates GitHub issue/PR links with titles and state badges | transform | GITHUB_TOKEN (optional) | in development | @choldgraf | - |
+| github-handle-links | Converts `@username` mentions to GitHub profile links | transform | GITHUB_TOKEN (optional) | in development | @choldgraf | - |
+| emoji-shortcodes | Converts emoji shortcodes (`:smile:`) to unicode emojis (😊) at build time | transform | | in development | Matt Fisher | - |
+| searchfilter | Adds a search bar that filters page elements matching a CSS selector by text content | directive (anywidget) | | in development | @choldgraf | - |
+
+
 ## Contribute
 We welcome new plugins! To share your plugin, please fork this repository, add your plugin, update the gallery table below and include an example page to demonstrate its output (note that the toc is in the toc.yml file), then submit a pull request. Edits and improvements to existing plugins are also encouraged.
 
@@ -21,20 +42,3 @@ It will print a `gh` command to generate a release for the plugin you specify.
 See the docstring of that script for usage information.
 
 **Note:** Release tags are named after the plugin (e.g., `github-issue-table`), not semantic versions. Future releases of the same plugin should update the existing release or use dated tags if versioning is needed.
-
-## Gallery of plugins
-|name|functionalities|type|requirements|status|maintainer(s)|Embed link|
-|---|---|---|---|---|---|---|
-| page-last-updated | A plugin that automatically slots in the latest update date per page | transform | requires to set fetch depth in deploy.yml `fetch-depth: 0` | tested | Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/page-last-updatedv1.1/page-last-updated.mjs) | 
-| experiment-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/experiment-admonition.mjs) |
-| intermezzo-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/intermezzo-admonition.mjs) |
-| example-admonition | A custom admonition with its transform for converting to pdf | directive & transform | requires custom css | stable | Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/Admonitions/example-admonition.mjs) |
-| ex-and-sol-pdf | A plugin that converts exercises and solutions to numbered exercises and solutions in both LaTeX and Typst pdf | transform | |stable |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/exercise-and-solution-pdf/exercise-admonition-pdf.mjs) |
-| updated-date-frontmatter | A plugin which adds the date of the last update to the top of the page | | |stable |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/updated-date-frontmatter/update-date-frontmatter.mjs) |
-| iframe | A plugin that replaces iframe elements with a qr code as figure and a caption with the link so that it is accessible in pdf format | transform | | in development |Luuk Fröling & Freek Pols | [Link](https://github.com/jupyter-book/myst-plugins/releases/download/iframe-to-qr-pdf/iframe-to-qr-pdf.mjs) |
-| picsum | A plugin that adds a directive to include random images from picsum.photos | directive | | stable | Angus Hollands | - |
-| typst-conversion-support | A plugin that converts missing conversions from Latex to Typst | transform | | in development | Freek Pols | - |
-| github-issue-table | Renders GitHub issues/PRs as tables from search queries or project URLs. Supports custom columns, multi-column sorting, styled labels, and project fields | directive | GITHUB_TOKEN | in development | @choldgraf | - |
-| github-issue-link | Automatically decorates GitHub issue/PR links with titles and state badges | transform | GITHUB_TOKEN (optional) | in development | @choldgraf | - |
-| github-handle-links | Converts `@username` mentions to GitHub profile links | transform | GITHUB_TOKEN (optional) | in development | @choldgraf | - |
-| emoji-shortcodes | Converts emoji shortcodes (`:smile:`) to unicode emojis (😊) at build time | transform | | in development | Matt Fisher | - |

--- a/example/searchfilter.md
+++ b/example/searchfilter.md
@@ -1,0 +1,111 @@
+---
+title: Search filter
+---
+```{include} ../plugins/searchfilter/README.md
+:start-line: 2
+```
+
+## Examples
+
+Here are a few examples of how you can filter various kinds of items by providing different values for the CSS selector argument.
+
+### Cards
+
+Use `.myst-card` to filter cards by their content.
+
+:::::{myst:demo}
+```{searchfilter} .myst-card
+```
+
+::::{grid} 3
+:::{card} Pandas
+A data analysis library for Python.
+:::
+
+:::{card} NumPy
+Fundamental package for scientific computing with Python.
+:::
+
+:::{card} Matplotlib
+A plotting library for Python.
+:::
+::::
+:::::
+
+### List items
+
+Use `li` to filter items in a list, and a `div` to filter multiple lists on a page.
+
+:::::{myst:demo}
+```{searchfilter} .example-list li
+```
+
+:::{div}
+:class: example-list
+- **Python** - General-purpose programming language
+- **Julia** - High-performance scientific computing
+- **R** - Statistical computing and graphics
+:::
+:::::
+
+### Table rows
+
+Use `tr` to filter rows of a table, and `:not(first-child)` to de-select the first row (e.g. title row).
+
+:::::{myst:demo}
+```{searchfilter} .example-table tr:not(:first-child)
+```
+
+:::{div}
+:class: example-table
+
+| Package | Language | Description |
+|---|---|---|
+| pandas | Python | Data analysis and manipulation |
+| NumPy | Python | Numerical computing |
+| SciPy | Python | Scientific computing |
+
+:::
+:::::
+
+### Restrict to certain content
+
+To restrict your `{searchfilter}` to only elements in the content area, use a parent selector and your own CSS class. For example:
+
+This restricts the search to those within a custom div you define:
+
+::::{myst:demo}
+```{searchfilter} .myclass li
+```
++++ {"class": "myclass"}
+- One
+- Two
+- Three
+:::::
+
+This uses [inline directive options](https://mystmd.org/guide/inline-options) to let you attach a class to the directive output:
+
+::::{myst:demo}
+```{searchfilter} .myclass tr
+```
+```{list-table .myclass}
+- - One
+- - Two
+- - Three
+```
+::::
+
+### Do not do this
+
+If you select a generic item on the page, then the searchfilter will remove stuff you don't want to remove!
+For example:
+
+:::::{myst:demo}
+This will select all `li` items on the page (including menu items etc)
+
+```{searchfilter} li
+```
+- One
+- Two
+- Three
+:::::

--- a/plugins.yml
+++ b/plugins.yml
@@ -21,3 +21,4 @@ project:
     - plugins/demo/src/index.mjs
     - plugins/emoji-shortcodes/emoji-shortcodes.mjs
     - plugins/page-last-updated/page-last-updated.mjs
+    - plugins/searchfilter/searchfilter.mjs

--- a/plugins/demo/src/index.mjs
+++ b/plugins/demo/src/index.mjs
@@ -36,6 +36,7 @@ function createDemoDirective(name) {
             border: "1px solid #e0e0e0",
             borderRadius: "4px",
             padding: "1rem",
+            marginBottom: "1rem",
           },
           children: [
             ...titleChildren,

--- a/plugins/searchfilter/README.md
+++ b/plugins/searchfilter/README.md
@@ -1,0 +1,44 @@
+# Search Filter
+
+Add a simple search bar to your MyST content that filters and subsets items on the page.
+
+> **Warning, this is kind of hacky!**: It "breaks out of the shadow DOM" for anywidgets which is **not recommended**.
+> The filter works by setting `style.display` on matched DOM elements.
+> This works well for static MyST content (cards, lists, tables), but if React re-renders an element after the filter has hidden it, the inline style will be reset.
+
+## Usage
+
+Add the plugin to your `myst.yml` file:
+
+```yaml
+project:
+  plugins:
+    - https://github.com/jupyter-book/myst-plugins/releases/latest/download/searchfilter.mjs
+```
+
+Then add a `{searchfilter}` directive with a CSS selector argument to select the items you'd like to search and filter. For example:
+
+````{myst:demo}
+```{searchfilter} .example-list li
+```
+
+:::{div}
+:class: example-list
+- One
+- Two
+- Three
+:::
+````
+
+This creates a search bar on the page. It uses the CSS selector to match elements, then hides any whose `textContent` doesn't contain the search query (case-insensitive).
+
+Search queries are automatically saved in the page URL as a `?searchfilter=` query parameter, so filtered views can be shared via link.
+
+## Architecture
+
+This is an [anywidget plugin](https://mystmd.org/guide/widgets) - it defines two kinds of things in a single file, so that we don't have to publish two artifacts with our github releases:
+
+- **Directive** - defines the `{searchfilter}` directive and returns an `anywidget` AST node.
+- **Widget** - defines the `render` function that creates the search UI and handles filtering (this is what :esm: points to).
+
+The logic computes the _path to itself_ when defining `:esm:` which seems to work, but is also definitely hacky.

--- a/plugins/searchfilter/searchfilter.mjs
+++ b/plugins/searchfilter/searchfilter.mjs
@@ -1,0 +1,164 @@
+/**
+ * Filter DOM items on a page with a user query.
+ *
+ * This provides a {searchfilter} directive that you call with a DOM query selector.
+ * It provides a search box for users.
+ * When users type in it, anything that matched your query will be filtered.
+ * 
+ * SVG search icon from Lucide (https://lucide.dev), licensed under the ISC License.
+ */
+
+// --- Widget (run by the browser) ---
+
+/** Run cleanup when the widget leaves the DOM. Usually because either:
+ * 1. React clobbered it
+ * 2. We've navigated pages w/ myst server active
+ */
+function onWidgetUnload(el, cleanup) {
+  let called = false;
+  function runOnce() {
+    if (called) return;
+    called = true;
+    watcher.disconnect();
+    window.removeEventListener('beforeunload', runOnce);
+    cleanup();
+  }
+  window.addEventListener('beforeunload', runOnce);
+  const watcher = new MutationObserver(() => {
+    if (!el.isConnected) runOnce();
+  });
+  watcher.observe(document.body, { childList: true, subtree: true });
+}
+
+const PARAM_KEY = 'searchfilter';
+
+/** Sync the current filter value to the URL so users can share/bookmark a filtered view. */
+function updateUrl(value) {
+  const url = new URL(window.location);
+  if (value) {
+    url.searchParams.set(PARAM_KEY, value);
+  } else {
+    url.searchParams.delete(PARAM_KEY);
+  }
+  history.replaceState(null, '', url);
+}
+
+/** Build the search input and wire up filtering. This is what anywidget calls. */
+function render({ model, el }) {
+  const selector = model.get('selector');
+  // We're scoping the whole document! That is to try and be unopinionated about the
+  // structure of the page, but it does mean users might shoot themselves in the foot.
+  // So we try to document this danger in the example.
+  const scope = document;
+
+  // Create the search box
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = 'position:relative;max-width:24rem;margin-bottom:1rem;';
+
+  // From Lucide (https://lucide.dev)
+  const icon = document.createElement('span');
+  icon.innerHTML =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>';
+  icon.style.cssText =
+    'position:absolute;left:0.6rem;top:50%;transform:translateY(-50%);pointer-events:none;line-height:0;';
+
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.placeholder = 'Filter items...';
+  input.style.cssText =
+    'width:100%;padding:0.5rem 2rem 0.5rem 2rem;font-size:0.9rem;border:1px solid #ccc;border-radius:6px;box-sizing:border-box;background:transparent;color:inherit;';
+
+  const clearBtn = document.createElement('button');
+  clearBtn.textContent = '\u00d7';
+  clearBtn.title = 'Clear search';
+  clearBtn.style.cssText =
+    'position:absolute;right:0.4rem;top:50%;transform:translateY(-50%);border:none;background:none;font-size:1.2rem;cursor:pointer;color:#888;padding:0 0.25rem;line-height:1;';
+  clearBtn.style.display = 'none';
+
+  const noResults = document.createElement('div');
+  noResults.textContent = '\u274c No items match search...';
+  noResults.style.cssText = 'display:none;margin-top:0.5rem;font-size:0.9rem;color:#888;';
+
+  /** Hide/show elements matching `selector` based on the current input value. */
+  function applyFilter() {
+    const query = input.value.toLowerCase();
+    clearBtn.style.display = query ? '' : 'none';
+    // Loop through the items we've matched and trigger them on/off
+    let visible = 0;
+    scope.querySelectorAll(selector).forEach((item) => {
+      // This is just a simple content text search, we could definitely make it fancier...
+      const show = !query || item.textContent.toLowerCase().includes(query);
+      item.style.display = show ? '' : 'none';
+      if (show) visible++;
+    });
+    // If we filter out all items, then show a little "no results" message
+    noResults.style.display = query && visible === 0 ? '' : 'none';
+    updateUrl(input.value);
+  }
+
+  input.addEventListener('input', applyFilter);
+
+  clearBtn.addEventListener('click', () => {
+    input.value = '';
+    applyFilter();
+  });
+
+  // Read from the URL if the parameter exists so we can restore/share a filtered view
+  const initial = new URL(window.location).searchParams.get(PARAM_KEY);
+  if (initial) {
+    input.value = initial;
+    applyFilter();
+  }
+
+  // Clean up if we've moved pages via React so URL params and scripts don't persist
+  onWidgetUnload(el, () => {
+    const url = new URL(window.location);
+    if (url.searchParams.has(PARAM_KEY)) {
+      url.searchParams.delete(PARAM_KEY);
+      history.replaceState(null, '', url);
+    }
+    scope.querySelectorAll(selector).forEach((item) => {
+      item.style.display = '';
+    });
+  });
+
+  wrapper.appendChild(icon);
+  wrapper.appendChild(input);
+  wrapper.appendChild(clearBtn);
+  el.appendChild(wrapper);
+  el.appendChild(noResults);
+}
+
+// --- Directive (aren't used in browser, just when the plugin builds locally w/ myst) ---
+
+let pathMod;
+try { pathMod = await import('node:path'); } catch {}
+const PLUGIN_PATH = new URL(import.meta.url).pathname;
+
+const searchfilterDirective = {
+  name: 'searchfilter',
+  doc: 'Adds a search bar that filters page elements matching a CSS selector by their text content.',
+  arg: {
+    type: String,
+    doc: 'A CSS selector for the elements to filter (e.g. .myst-card)',
+  },
+  run(data, vfile) {
+    const selector = (data.arg ?? '').trim();
+    const esm = pathMod.relative(pathMod.dirname(vfile.path), PLUGIN_PATH);
+    return [
+      {
+        type: 'anywidget',
+        esm,
+        model: { selector },
+        id: Math.random().toString(36).slice(2),
+      },
+    ];
+  },
+};
+
+// We export *both* the directive definition *and* the render function
+export default {
+  name: 'searchfilter',
+  directives: [searchfilterDirective],
+  render,
+};

--- a/toc.yml
+++ b/toc.yml
@@ -11,6 +11,7 @@ project:
     - file: example/update-date.md   
     - file: example/page-last-updated.md
     - file: example/emoji-shortcodes.md
+    - file: example/searchfilter.md
     - file: example/footer.md
 
     - title: GitHub Plugins


### PR DESCRIPTION
This adds a little plugin that provides a "search bar" on the page, allowing the user to filter items on the page according to the search. It's a little bit hacky - the author has to provide a `querySelector` query to choose the items they want to filter. I think this is good though, it means you need to know a bit about web dev to use this, which means you're less likely to be unpleasantly surprised by the results. I also tried to document a bunch of caveats about this.

I also moved our table of plugins up, and added a search filter for it!