### PR TITLE
Editable Pyodide Code Cells Plugin — Client-side, Offline-capable Python Editor with syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is (as yet) a non-official repository for MyST plugins.
 | github-handle-links | Converts `@username` mentions to GitHub profile links | transform | GITHUB_TOKEN (optional) | in development | @choldgraf | - |
 | emoji-shortcodes | Converts emoji shortcodes (`:smile:`) to unicode emojis (😊) at build time | transform | | in development | Matt Fisher | - |
 | searchfilter | Adds a search bar that filters page elements matching a CSS selector by text content | directive (anywidget) | | in development | @choldgraf | - |
+| pyodide-editable | Adds editable Python cells that execute in the browser with Pyodide | directive | loads Pyodide, CodeMirror, and Python packages from CDN | in development | @chandraveshchaudhari | - |
 
 
 ## Contribute

--- a/example/pyodide-editable.md
+++ b/example/pyodide-editable.md
@@ -1,0 +1,71 @@
+---
+title: Pyodide Editable demo
+---
+This page demonstrates two richer examples using Pyodide: a `pandas` data example and a `matplotlib` plot. Both the container `pyodide-cell` form and the fenced directive form are shown.
+
+## Pandas example (container form)
+
+:::{pyodide-cell}
+:id: pandas-demo
+
+import pandas as pd
+
+data = {
+    "City":        ["Delhi", "Mumbai", "Bengaluru", "Chennai"],
+    "Population":  [32.9, 20.7, 13.2, 10.9],   # millions
+    "Area_km2":    [1484, 603, 741, 426],
+}
+
+df = pd.DataFrame(data)
+df["Density"] = (df["Population"] * 1e6 / df["Area_km2"]).round(0)
+print(df.to_string(index=False))
+print(f"\nMost dense: {df.loc[df.Density.idxmax(), 'City']}")
+:::
+
+---
+
+## Matplotlib plot (container form)
+
+:::{pyodide-cell}
+:id: matplotlib-demo
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+t = np.linspace(0, 4 * np.pi, 400)
+
+fig, axes = plt.subplots(1, 2, figsize=(9, 3.5))
+
+axes[0].plot(t, np.sin(t), color='steelblue', lw=2, label='sin(t)')
+axes[0].plot(t, np.cos(t), color='tomato',    lw=2, label='cos(t)')
+axes[0].set_title('Trigonometric functions')
+axes[0].legend()
+axes[0].grid(alpha=0.3)
+
+axes[1].plot(t, np.exp(-0.2 * t) * np.sin(t * 3),
+             color='seagreen', lw=2, label='damped oscillation')
+axes[1].set_title('Damped oscillation')
+axes[1].legend()
+axes[1].grid(alpha=0.3)
+
+plt.tight_layout()
+plt.show()
+:::
+
+---
+
+## Same examples (fenced directive form)
+
+```{pyodide}
+import pandas as pd
+data = {"City":["Delhi","Mumbai"],"Population":[32.9,20.7],"Area_km2":[1484,603]}
+df = pd.DataFrame(data)
+print(df)
+```
+
+```{pyodide}
+import numpy as np
+import matplotlib.pyplot as plt
+plt.plot([0,1,2],[0,1,0])
+plt.show()
+```

--- a/example/pyodide-editable.md
+++ b/example/pyodide-editable.md
@@ -1,13 +1,16 @@
 ---
-title: Pyodide Editable demo
+title: Editable Pyodide Cells
 ---
+
+```{include} ../plugins/pyodide-editable/README.md
+:start-line: 2
+```
+
 This page demonstrates two richer examples using Pyodide: a `pandas` data example and a `matplotlib` plot. Both the container `pyodide-cell` form and the fenced directive form are shown.
 
-## Pandas example (container form)
+## Pandas example
 
-:::{pyodide-cell}
-:id: pandas-demo
-
+```{pyodide}
 import pandas as pd
 
 data = {
@@ -20,11 +23,11 @@ df = pd.DataFrame(data)
 df["Density"] = (df["Population"] * 1e6 / df["Area_km2"]).round(0)
 print(df.to_string(index=False))
 print(f"\nMost dense: {df.loc[df.Density.idxmax(), 'City']}")
-:::
+```
 
 ---
 
-## Matplotlib plot (container form)
+## Matplotlib plot
 
 :::{pyodide-cell}
 :id: matplotlib-demo
@@ -52,20 +55,3 @@ plt.tight_layout()
 plt.show()
 :::
 
----
-
-## Same examples (fenced directive form)
-
-```{pyodide}
-import pandas as pd
-data = {"City":["Delhi","Mumbai"],"Population":[32.9,20.7],"Area_km2":[1484,603]}
-df = pd.DataFrame(data)
-print(df)
-```
-
-```{pyodide}
-import numpy as np
-import matplotlib.pyplot as plt
-plt.plot([0,1,2],[0,1,0])
-plt.show()
-```

--- a/plugins.yml
+++ b/plugins.yml
@@ -22,3 +22,4 @@ project:
     - plugins/emoji-shortcodes/emoji-shortcodes.mjs
     - plugins/page-last-updated/page-last-updated.mjs
     - plugins/searchfilter/searchfilter.mjs
+    - plugins/pyodide-editable/pyodide-editable.mjs

--- a/plugins/pyodide-editable/README.md
+++ b/plugins/pyodide-editable/README.md
@@ -1,4 +1,4 @@
-# Pyodide Editable
+# Editable Pyodide Cells
 
 `pyodide-editable` adds an editable Python cell directive to MyST sites. Each
 cell is rendered in the browser with editor controls and executed with Pyodide,

--- a/plugins/pyodide-editable/README.md
+++ b/plugins/pyodide-editable/README.md
@@ -1,0 +1,42 @@
+# Pyodide Editable
+
+`pyodide-editable` adds an editable Python cell directive to MyST sites. Each
+cell is rendered in the browser with editor controls and executed with Pyodide,
+so examples can run without a separate Jupyter server.
+
+## Usage
+
+Add the plugin to `myst.yml`:
+
+```yaml
+project:
+  plugins:
+    - plugins/pyodide-editable/pyodide-editable.mjs
+```
+
+Then add a cell to a page:
+
+````markdown
+```{pyodide}
+print("Hello from Pyodide")
+```
+````
+
+The longer directive form supports an optional stable id:
+
+````markdown
+:::{pyodide-cell}
+:id: pandas-demo
+
+import pandas as pd
+df = pd.DataFrame({"x": [1, 2, 3]})
+print(df)
+:::
+````
+
+## Notes
+
+The plugin uses an anywidget renderer for the browser UI. It bundles the local
+Pyodide runner/transform helpers and loads Pyodide from jsDelivr. The first
+execution can take a few seconds while Pyodide and common scientific packages
+load.

--- a/plugins/pyodide-editable/pyodide-editable.mjs
+++ b/plugins/pyodide-editable/pyodide-editable.mjs
@@ -1,0 +1,46 @@
+const PLUGIN_PATH = new URL(import.meta.url).pathname;
+const WIDGET_PATH = PLUGIN_PATH.replace(/\/[^/]*$/, "/widget.mjs");
+
+function relativePath(fromDir, toFile) {
+  const from = fromDir.split("/").filter(Boolean);
+  const to = toFile.split("/").filter(Boolean);
+  let i = 0;
+  while (i < from.length && i < to.length && from[i] === to[i]) i++;
+  return [...Array(from.length - i).fill(".."), ...to.slice(i)].join("/") || ".";
+}
+
+const pyodideDirective = {
+  name: "pyodide-cell",
+  alias: ["pyodide", "myst:pyodide", "myst:pyodide-cell", "python-cell"],
+  doc: "Render an editable Pyodide-backed Python code cell.",
+  body: { type: String, required: true },
+  options: {
+    id: { type: String, doc: "Optional id for the cell." },
+    packages: { type: String, doc: "Comma-separated Pyodide packages." },
+  },
+  run(data, vfile) {
+    const code = (data.body || "").trim();
+    if (!code) return [];
+
+    const fromDir = vfile.path.replace(/\/[^/]*$/, "");
+    const esm = relativePath(fromDir, WIDGET_PATH);
+
+    return [
+      {
+        type: "anywidget",
+        esm,
+        model: {
+          code,
+          id: data.options?.id?.trim() || "",
+          packages: data.options?.packages?.trim() || "",
+        },
+        id: data.options?.id?.trim() || Math.random().toString(36).slice(2),
+      },
+    ];
+  },
+};
+
+export default {
+  name: "Pyodide Editable",
+  directives: [pyodideDirective],
+};

--- a/plugins/pyodide-editable/widget.mjs
+++ b/plugins/pyodide-editable/widget.mjs
@@ -1,0 +1,363 @@
+const PYODIDE_CDN = "https://cdn.jsdelivr.net/pyodide/v0.29.3/full/";
+const DEFAULT_PACKAGES = ["numpy", "pandas", "matplotlib"];
+
+let pyodideInstance = null;
+let loadingPromise = null;
+let loadState = "idle";
+let loadError = null;
+const runButtons = new Set();
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+      existing.addEventListener("load", resolve, { once: true });
+      existing.addEventListener("error", reject, { once: true });
+      resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = src;
+    script.onload = resolve;
+    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+async function loadPyodideRuntime(extraPackages = []) {
+  if (pyodideInstance) {
+    if (extraPackages.length) await pyodideInstance.loadPackage(extraPackages);
+    return pyodideInstance;
+  }
+  if (!loadingPromise) {
+    loadingPromise = (async () => {
+      if (typeof globalThis.loadPyodide !== "function") {
+        await loadScript(`${PYODIDE_CDN}pyodide.js`);
+      }
+      const pyodide = await globalThis.loadPyodide({ indexURL: PYODIDE_CDN });
+      await pyodide.loadPackage(DEFAULT_PACKAGES);
+      pyodide.runPython(`
+import sys, io, js
+
+class _JsBridge(io.TextIOBase):
+    def __init__(self, tag):
+        self._tag = tag
+    def write(self, s):
+        js.globalThis._pyodideStreamWrite(self._tag, s)
+        return len(s)
+    def flush(self):
+        pass
+
+sys.stdout = _JsBridge("stdout")
+sys.stderr = _JsBridge("stderr")
+      `);
+      pyodide.runPython(`
+import matplotlib
+matplotlib.use("agg")
+      `);
+      pyodideInstance = pyodide;
+      return pyodide;
+    })();
+  }
+  const pyodide = await loadingPromise;
+  if (extraPackages.length) await pyodide.loadPackage(extraPackages);
+  return pyodide;
+}
+
+globalThis._pyodideStreamWrite = function pyodideStreamWrite(tag, text) {
+  if (!globalThis._pyodideCurrentCell) return;
+  const buffer = globalThis._pyodideCurrentCell;
+  buffer[tag] += text;
+};
+
+async function restartKernel() {
+  if (pyodideInstance) {
+    try {
+      pyodideInstance.runPython("import sys; sys.stdout = sys.__stdout__; sys.stderr = sys.__stderr__");
+    } catch {
+      // Ignore cleanup failures; the runtime is about to be replaced.
+    }
+  }
+  pyodideInstance = null;
+  loadingPromise = null;
+  loadState = "idle";
+  loadError = null;
+}
+
+async function executePython(code, packages) {
+  const pyodide = await loadPyodideRuntime(packages);
+  const capture = { stdout: "", stderr: "" };
+  globalThis._pyodideCurrentCell = capture;
+
+  pyodide.runPython(`
+import matplotlib.pyplot as plt
+plt.close('all')
+  `);
+
+  const started = performance.now();
+  let error = null;
+  let returnValue = null;
+
+  try {
+    const value = await pyodide.runPythonAsync(code);
+    if (value !== undefined && value !== null) returnValue = String(value);
+  } catch (err) {
+    error = String(err);
+  } finally {
+    globalThis._pyodideCurrentCell = null;
+  }
+
+  let figures = [];
+  try {
+    const figureJson = pyodide.runPython(`
+import matplotlib.pyplot as plt, io, base64, json
+_figs = []
+for _fig_num in plt.get_fignums():
+    _fig = plt.figure(_fig_num)
+    _buf = io.BytesIO()
+    _fig.savefig(_buf, format='png', bbox_inches='tight', dpi=120)
+    _buf.seek(0)
+    _figs.append('data:image/png;base64,' + base64.b64encode(_buf.read()).decode())
+    plt.close(_fig)
+json.dumps(_figs)
+    `);
+    figures = JSON.parse(figureJson);
+  } catch {
+    figures = [];
+  }
+
+  return {
+    stdout: capture.stdout,
+    stderr: capture.stderr,
+    error,
+    returnValue,
+    figures,
+    durationMs: Math.round(performance.now() - started),
+  };
+}
+
+function appendToWidgetRoot(el, node) {
+  const root = el.getRootNode && el.getRootNode();
+  if (root && root !== document && root.appendChild) {
+    root.appendChild(node);
+    return;
+  }
+  document.head.appendChild(node);
+}
+
+function rootHasElement(el, id) {
+  const root = el.getRootNode && el.getRootNode();
+  if (root && root !== document && root.getElementById) return root.getElementById(id);
+  return document.getElementById(id);
+}
+
+function ensureStyles(el) {
+  if (rootHasElement(el, "pyodide-editable-widget-styles")) return;
+  const style = document.createElement("style");
+  style.id = "pyodide-editable-widget-styles";
+  style.textContent = `
+.pyodide-wrapper{box-sizing:border-box;width:100%;border:1px solid var(--color-border,#d0d7de);border-radius:6px;overflow:hidden;margin:1.25rem 0;background:var(--color-background-primary,#fff);color:var(--color-foreground-primary,#1f2328);font:0.875rem ui-monospace,SFMono-Regular,Menlo,monospace}
+.pyodide-header,.pyodide-status-bar{display:flex;align-items:center;justify-content:space-between;padding:.45rem .75rem;background:var(--color-background-secondary,#f6f8fa);border-bottom:1px solid var(--color-border,#d0d7de);gap:.5rem}
+.pyodide-status-bar{border-top:1px solid var(--color-border,#d0d7de);border-bottom:0;min-height:1.6rem}
+.pyodide-controls{display:flex;flex-wrap:wrap;gap:.4rem;justify-content:flex-end}
+.pyodide-btn{display:inline-flex;align-items:center;gap:.3rem;padding:.35rem .65rem;border-radius:5px;border:1px solid var(--color-border,#d0d7de);font:inherit;font-size:.8rem;line-height:1;cursor:pointer;background:var(--color-background-primary,#fff);color:inherit}
+.pyodide-btn:disabled{opacity:.5;cursor:not-allowed}
+.pyodide-btn-run,.pyodide-btn-runall{background:#1a7f37;color:white;border-color:rgba(31,35,40,.15);font-weight:600}
+.pyodide-btn-runall{background:#0969da}
+.pyodide-btn-restart{color:#cf222e;font-weight:600}
+.pyodide-lang-badge{font-size:.72rem;font-weight:700;text-transform:uppercase;color:var(--color-foreground-muted,#57606a);letter-spacing:.04em}
+.pyodide-editor{box-sizing:border-box;display:block;width:100%;min-height:10rem;max-height:26rem;padding:.75rem;border:0;border-radius:0;resize:vertical;background:var(--color-background-primary,#fafbfc);color:inherit;font:inherit;line-height:1.55;tab-size:4;outline:none}
+.pyodide-output{min-height:2.5rem;max-height:25rem;overflow:auto;padding:.7rem .75rem;border-top:1px solid var(--color-border,#d0d7de);background:var(--color-background-primary,#fff);resize:vertical}
+.pyodide-output[hidden]{display:none}
+.pyodide-output pre{margin:0 0 .4rem!important;padding:0!important;background:transparent!important;border:0!important;color:inherit!important;white-space:pre-wrap;word-break:break-word;font:inherit}
+.pyodide-error,.pyodide-stderr{color:#cf222e}
+.pyodide-figure{display:block;max-width:100%;height:auto;margin:.5rem 0}
+.pyodide-status-text{font-size:.78rem;color:var(--color-foreground-muted,#57606a)}
+.pyodide-status-info{color:#0550ae}.pyodide-status-success{color:#1a7f37}.pyodide-status-error{color:#cf222e}
+.pyodide-timing{font-size:.75rem;color:var(--color-foreground-muted,#8c959f);font-variant-numeric:tabular-nums}
+`;
+  appendToWidgetRoot(el, style);
+}
+
+function setStatus(statusText, message, type = "info") {
+  statusText.textContent = message;
+  statusText.className = `pyodide-status-text pyodide-status-${type}`;
+}
+
+function renderOutput(outputArea, result) {
+  outputArea.innerHTML = "";
+  outputArea.hidden = false;
+  let hasContent = false;
+
+  for (const [key, className] of [
+    ["stdout", "pyodide-stdout"],
+    ["stderr", "pyodide-stderr"],
+    ["error", "pyodide-error"],
+    ["returnValue", "pyodide-return-value"],
+  ]) {
+    if (!result[key]) continue;
+    hasContent = true;
+    const pre = document.createElement("pre");
+    pre.className = className;
+    pre.textContent = result[key];
+    outputArea.appendChild(pre);
+  }
+
+  for (const figure of result.figures || []) {
+    hasContent = true;
+    const img = document.createElement("img");
+    img.src = figure;
+    img.alt = "matplotlib figure";
+    img.className = "pyodide-figure";
+    outputArea.appendChild(img);
+  }
+
+  if (!hasContent) outputArea.hidden = true;
+}
+
+async function runAllCells() {
+  for (const button of Array.from(runButtons)) {
+    if (!button.isConnected) {
+      runButtons.delete(button);
+      continue;
+    }
+    button.click();
+    while (button.disabled) {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+  }
+}
+
+function render({ model, el }) {
+  const code = model.get("code") || "";
+  const cellId = model.get("id") || "";
+  const packages = (model.get("packages") || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  ensureStyles(el);
+  el.innerHTML = "";
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "pyodide-wrapper";
+  wrapper.setAttribute("role", "region");
+  wrapper.setAttribute("aria-label", "Interactive Python cell");
+  if (cellId) wrapper.id = `pycell-${cellId}`;
+
+  const header = document.createElement("div");
+  header.className = "pyodide-header";
+  const badge = document.createElement("span");
+  badge.className = "pyodide-lang-badge";
+  badge.textContent = "Python";
+  const controls = document.createElement("div");
+  controls.className = "pyodide-controls";
+
+  const runButton = document.createElement("button");
+  runButton.type = "button";
+  runButton.className = "pyodide-btn pyodide-btn-run";
+  runButton.textContent = "Run";
+
+  const clearButton = document.createElement("button");
+  clearButton.type = "button";
+  clearButton.className = "pyodide-btn pyodide-btn-clear";
+  clearButton.textContent = "Clear";
+
+  const runAllButton = document.createElement("button");
+  runAllButton.type = "button";
+  runAllButton.className = "pyodide-btn pyodide-btn-runall";
+  runAllButton.textContent = "Run All";
+
+  const restartButton = document.createElement("button");
+  restartButton.type = "button";
+  restartButton.className = "pyodide-btn pyodide-btn-restart";
+  restartButton.textContent = "Restart";
+
+  controls.append(runButton, clearButton, runAllButton, restartButton);
+  header.append(badge, controls);
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "pyodide-editor";
+  textarea.value = code;
+  textarea.spellcheck = false;
+  textarea.setAttribute("aria-label", "Python code editor");
+
+  const statusBar = document.createElement("div");
+  statusBar.className = "pyodide-status-bar";
+  const statusText = document.createElement("span");
+  statusText.className = "pyodide-status-text";
+  const timing = document.createElement("span");
+  timing.className = "pyodide-timing";
+  statusBar.append(statusText, timing);
+
+  const outputArea = document.createElement("div");
+  outputArea.className = "pyodide-output";
+  outputArea.setAttribute("aria-live", "polite");
+  outputArea.hidden = true;
+
+  wrapper.append(header, textarea, statusBar, outputArea);
+  el.appendChild(wrapper);
+  runButtons.add(runButton);
+
+  clearButton.addEventListener("click", () => {
+    outputArea.innerHTML = "";
+    outputArea.hidden = true;
+    timing.textContent = "";
+    setStatus(statusText, "");
+  });
+
+  restartButton.addEventListener("click", async () => {
+    restartButton.disabled = true;
+    setStatus(statusText, "Restarting kernel...", "info");
+    await restartKernel();
+    setStatus(statusText, "Kernel restarted", "success");
+    restartButton.disabled = false;
+  });
+
+  runAllButton.addEventListener("click", runAllCells);
+
+  runButton.addEventListener("click", async () => {
+    runButton.disabled = true;
+    outputArea.hidden = true;
+    outputArea.innerHTML = "";
+    timing.textContent = "";
+
+    try {
+      if (loadState === "idle") {
+        loadState = "loading";
+        setStatus(statusText, "Loading Pyodide (first run, may take a few seconds)...", "info");
+        try {
+          await loadPyodideRuntime(packages);
+          loadState = "ready";
+        } catch (err) {
+          loadState = "error";
+          loadError = String(err);
+        }
+      }
+
+      if (loadState === "loading") {
+        setStatus(statusText, "Waiting for Pyodide...", "info");
+        while (loadState === "loading") {
+          await new Promise((resolve) => setTimeout(resolve, 150));
+        }
+      }
+
+      if (loadState === "error") {
+        setStatus(statusText, `Failed to load Pyodide: ${loadError}`, "error");
+        return;
+      }
+
+      setStatus(statusText, "Running...", "info");
+      const result = await executePython(textarea.value, packages);
+      renderOutput(outputArea, result);
+      timing.textContent = `${result.durationMs} ms`;
+      setStatus(statusText, result.error ? "Error" : "Done", result.error ? "error" : "success");
+    } catch (err) {
+      setStatus(statusText, `Error: ${err}`, "error");
+    } finally {
+      runButton.disabled = false;
+    }
+  });
+}
+
+export default { render };

--- a/toc.yml
+++ b/toc.yml
@@ -12,6 +12,7 @@ project:
     - file: example/page-last-updated.md
     - file: example/emoji-shortcodes.md
     - file: example/searchfilter.md
+    - file: example/pyodide-editable.md
     - file: example/footer.md
 
     - title: GitHub Plugins
@@ -33,4 +34,3 @@ project:
       - file: example/experiment.md    
       - file: example/intermezzo.md
       - file: example/example.md
-


### PR DESCRIPTION
Adds a plugin `pyodide-editable` that provides **editable, syntax-highlighted Python code** cells powered by Pyodide, enabling in-browser execution with no backend dependency. Cells remain usable offline after the initial asset load and include configuration options plus an example demonstrating integration and usage.